### PR TITLE
Use automatic section numbering

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -68,6 +68,7 @@ url = "https://www.acend.ch"
   # guessSyntax = "true"
 
 [params]
+automaticSectionNumbers = true
 copyright = "acend gmbh"
 github_repo = "https://github.com/acend/cilium-basics-training"
 github_branch = "main"

--- a/content/en/docs/01/01/_index.md
+++ b/content/en/docs/01/01/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "eBPF"
 weight: 11
-sectionnumber: 1.1
 ---
 
 ## What is eBPF

--- a/content/en/docs/01/01/_index.md
+++ b/content/en/docs/01/01/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "1.1 eBPF"
+title: "eBPF"
 weight: 11
 sectionnumber: 1.1
 ---

--- a/content/en/docs/01/_index.md
+++ b/content/en/docs/01/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "1. Introduction"
+title: "Introduction"
 weight: 1
 sectionnumber: 1
 ---

--- a/content/en/docs/01/_index.md
+++ b/content/en/docs/01/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Introduction"
 weight: 1
-sectionnumber: 1
 ---
 
 

--- a/content/en/docs/02/01/_index.md
+++ b/content/en/docs/02/01/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Install Cilium"
 weight: 21
-sectionnumber: 2.1
 ---
 
 Cilium can be installed using multiple ways:
@@ -13,7 +12,7 @@ In this lab, we are going to use [Helm](https://helm.sh) which is recommended fo
 The [Cilium command-line](https://github.com/cilium/cilium-cli/) tool is used (Cilium CLI) for verification and troubleshooting.
 
 
-## Task {{% param sectionnumber %}}.1: Install a Kubernetes Cluster
+## {{% task %}} Install a Kubernetes Cluster
 
 We are going to spin up a new Kubernetes cluster with the following command:
 
@@ -77,7 +76,7 @@ But you should not see any CNI related pods!
 {{% /alert %}}
 
 
-## Task {{% param sectionnumber %}}.2: Install Cilium CLI
+## {{% task %}} Install Cilium CLI
 
 The `cilium` CLI tool is a single binary file that can be downloaded from the project's release page. Follow the instructions depending on your operating system or environment.
 
@@ -157,7 +156,7 @@ Errors:          cilium    cilium    daemonsets.apps "cilium" not found
 We don't have yet installed Cilium, therefore the error is perfectly fine.
 
 
-## Task {{% param sectionnumber %}}.3: Install Cilium
+## {{% task %}}  Install Cilium
 
 Let's install Cilium with Helm. First we need to add the Cilium Helm repository:
 
@@ -328,7 +327,7 @@ kubectl delete ns cilium-test --wait=false
 ```
 
 
-## Task {{% param sectionnumber %}}.4: Explore your installation
+## {{% task %}} Explore your installation
 
 We have learned about the Cilium components. Let us check out the installed CRDs now:
 

--- a/content/en/docs/02/01/_index.md
+++ b/content/en/docs/02/01/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "2.1 Install Cilium"
+title: "Install Cilium"
 weight: 21
 sectionnumber: 2.1
 ---
@@ -22,7 +22,7 @@ To start from a clean Kubernetes cluster, make sure `cluster1` is not yet availa
 {{% /alert %}}
 
 ```bash
-minikube start --network-plugin=cni --cni=false --kubernetes-version={{% param "kubernetesVersion" %}} -p cluster1 
+minikube start --network-plugin=cni --cni=false --kubernetes-version={{% param "kubernetesVersion" %}} -p cluster1
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -139,7 +139,7 @@ cilium status
 ```
 
 ```
-cilium status 
+cilium status
     /¯¯\
  /¯¯\__/¯¯\    Cilium:         1 errors
  \__/¯¯\__/    Operator:       disabled
@@ -147,8 +147,8 @@ cilium status
  \__/¯¯\__/    ClusterMesh:    disabled
     \__/
 
-Containers:      cilium             
-                 cilium-operator    
+Containers:      cilium
+                 cilium-operator
 Cluster Pods:    0/0 managed by Cilium
 Errors:          cilium    cilium    daemonsets.apps "cilium" not found
 
@@ -205,7 +205,7 @@ cilium status --wait
 command:
 
 ```
-cilium status 
+cilium status
     /¯¯\
  /¯¯\__/¯¯\    Cilium:         OK
  \__/¯¯\__/    Operator:       OK
@@ -355,7 +355,7 @@ kubectl get ccnp,cep,cew,ciliumid,cnp,cn -A
 We see 1 node, 1 identity and 1 endpoint:
 ```bash
 NAMESPACE     NAME                                               ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4         IPV6
-kube-system   ciliumendpoint.cilium.io/coredns-64897985d-7485t   465           67688                                                                        ready            10.1.0.215   
+kube-system   ciliumendpoint.cilium.io/coredns-64897985d-7485t   465           67688                                                                        ready            10.1.0.215
 
 NAMESPACE   NAME                             NAMESPACE     AGE
             ciliumidentity.cilium.io/67688   kube-system   18m

--- a/content/en/docs/02/02/_index.md
+++ b/content/en/docs/02/02/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "2.2 Upgrade Cilium"
+title: "Upgrade Cilium"
 weight: 22
 OnlyWhenNot: techlab
 sectionnumber: 2.2

--- a/content/en/docs/02/02/_index.md
+++ b/content/en/docs/02/02/_index.md
@@ -2,13 +2,12 @@
 title: "Upgrade Cilium"
 weight: 22
 OnlyWhenNot: techlab
-sectionnumber: 2.2
 ---
 
 In the previous lab, we intentionally installed version `v{{% param "ciliumVersion.preUpgrade" %}}` of Cilium. In this lab, we show you how to upgrade this installation.
 
 
-## Task {{% param sectionnumber %}}.1: Running pre-flight check
+## {{% task %}} Running pre-flight check
 
 When rolling out an upgrade with Kubernetes, Kubernetes will first terminate the Pod followed by pulling the new image version and then finally spin up the new image. In order to reduce the downtime of the agent and to prevent `ErrImagePull` errors during the upgrade, the pre-flight check pre-pulls the new image version. If you are running in "Kubernetes Without kube-proxy" mode you must also pass on the Kubernetes API Server IP and/or the Kubernetes API Server Port when generating the `cilium-preflight.yaml` file.
 
@@ -22,7 +21,7 @@ helm install cilium-preflight cilium/cilium --version {{% param "ciliumVersion.p
 ```
 
 
-## Task {{% param sectionnumber %}}.2: Clean up pre-flight check
+## {{% task %}} Clean up pre-flight check
 
 
 To check the preflight Pods we check if the pods are `READY` using:
@@ -45,7 +44,7 @@ helm delete cilium-preflight --namespace=kube-system
 ```
 
 
-## Task {{% param sectionnumber %}}.3: Upgrading Cilium
+## {{% task %}} Upgrading Cilium
 
 During normal cluster operations, all Cilium components should run the same version. Upgrading just one of them (e.g., upgrading the agent without upgrading the operator) could result in unexpected cluster behavior. The following steps will describe how to upgrade all of the components from one stable release to a later stable release.
 
@@ -77,7 +76,7 @@ The `--reuse-values` flag may only be safely used if the Cilium chart version re
 {{% /alert %}}
 
 
-## Task {{% param sectionnumber %}}.4: Explore your installation after the upgrade
+## {{% task %}} Explore your installation after the upgrade
 
 We can run:
 

--- a/content/en/docs/02/_index.md
+++ b/content/en/docs/02/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "2. Install Cilium"
+title: "Install Cilium"
 weight: 2
 sectionnumber: 2
 ---

--- a/content/en/docs/02/_index.md
+++ b/content/en/docs/02/_index.md
@@ -1,5 +1,4 @@
 ---
 title: "Install Cilium"
 weight: 2
-sectionnumber: 2
 ---

--- a/content/en/docs/03/01/_index.md
+++ b/content/en/docs/03/01/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "3.1 Hubble"
+title: "Hubble"
 weight: 31
 sectionnumber: 3.1
 ---
@@ -140,9 +140,9 @@ replicaset.apps/frontend-76fbb99468      1         1         1       3m17s
 replicaset.apps/not-frontend-8f467ccbd   1         1         1       3m17s
 
 NAME                                                    ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4         IPV6
-ciliumendpoint.cilium.io/backend-65f7c794cc-b9j66       144           67823                                                                        ready            10.1.0.44    
-ciliumendpoint.cilium.io/frontend-76fbb99468-mbzcm      1898          76556                                                                        ready            10.1.0.161   
-ciliumendpoint.cilium.io/not-frontend-8f467ccbd-cbks8   208           127021                                                                       ready            10.1.0.128   
+ciliumendpoint.cilium.io/backend-65f7c794cc-b9j66       144           67823                                                                        ready            10.1.0.44
+ciliumendpoint.cilium.io/frontend-76fbb99468-mbzcm      1898          76556                                                                        ready            10.1.0.161
+ciliumendpoint.cilium.io/not-frontend-8f467ccbd-cbks8   208           127021                                                                       ready            10.1.0.128
 
 NAME                              NAMESPACE     AGE
 ciliumidentity.cilium.io/127021   default       3m15s

--- a/content/en/docs/03/01/_index.md
+++ b/content/en/docs/03/01/_index.md
@@ -1,13 +1,12 @@
 ---
 title: "Hubble"
 weight: 31
-sectionnumber: 3.1
 ---
 
 Before we start with the CNI functionality of Cilium and its security components we want to enable the optional Hubble component (which is disabled by default). So we can take full advantage of its eBFP observability capabilities.
 
 
-## Task {{% param sectionnumber %}}.1: Install the Hubble CLI
+## {{% task %}} Install the Hubble CLI
 
 Similar to the `cilium` CLI, the `hubble` CLI interfaces with Hubble and allows observing network traffic within Kubernetes.
 
@@ -86,7 +85,7 @@ Use "hubble [command] --help" for more information about a command.
 ```
 
 
-## Task {{% param sectionnumber %}}.2: Deploy a simple application
+## {{% task %}} Deploy a simple application
 
 Before we enable Hubble in Cilium we want to make sure we have at least one application to observe.
 
@@ -162,7 +161,7 @@ echo ${NOT_FRONTEND}
 ```
 
 
-## Task {{% param sectionnumber %}}.3: Enable Hubble in Cilium
+## {{% task %}} Enable Hubble in Cilium
 
 When you install Cilium using Helm, then Hubble is already enabled. The value for this is `hubble.enabled` which is set to `true` in the `values.yaml` of the Cilium Helm Chart. But we also want to enable Hubble Relay. With the following Helm command you can enable Hubble with Hubble Relay:
 
@@ -286,7 +285,7 @@ If the nodes are not yet connected, give it some time and try again. There is a 
 The Hubble CLI is now primed for observing network traffic within the cluster.
 
 
-## Task {{% param sectionnumber %}}.4: Observing flows with Hubble
+## {{% task %}} Observing flows with Hubble
 
 We now want to use the `hubble` CLI to observe some network flows in our Kubernetes cluster. Let us have a look at the following command:
 

--- a/content/en/docs/03/02/_index.md
+++ b/content/en/docs/03/02/_index.md
@@ -1,13 +1,12 @@
 ---
 title: "Hubble UI"
 weight: 32
-sectionnumber: 3.2
 ---
 
 Not only does Hubble allow us to inspect flows from the command line, but it also allows us to see them in real-time on a graphical service map via Hubble UI. Again, this also is an optional component that is disabled by default.
 
 
-## Task {{% param sectionnumber %}}.1: Enable the Hubble UI component
+## {{% task %}} Enable the Hubble UI component
 
 Enabling the optional Hubble UI component with Helm looks like this:
 

--- a/content/en/docs/03/02/_index.md
+++ b/content/en/docs/03/02/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "3.2 Hubble UI"
+title: "Hubble UI"
 weight: 32
 sectionnumber: 3.2
 ---

--- a/content/en/docs/03/_index.md
+++ b/content/en/docs/03/_index.md
@@ -1,5 +1,4 @@
 ---
 title: "Hubble"
 weight: 3
-sectionnumber: 3
 ---

--- a/content/en/docs/03/_index.md
+++ b/content/en/docs/03/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "3. Hubble"
+title: "Hubble"
 weight: 3
 sectionnumber: 3
 ---

--- a/content/en/docs/04/_index.md
+++ b/content/en/docs/04/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Metrics"
 weight: 4
-sectionnumber: 4
 OnlyWhenNot: techlab
 ---
 
@@ -11,7 +10,7 @@ Both Cilium and Hubble can be configured to serve Prometheus metrics independent
 Hubble metrics on the other hand give us information about the traffic of our applications.
 
 
-## Task {{% param sectionnumber %}}.1:  Enable metrics
+## {{% task %}} Enable metrics
 
 We start by enabling different metrics, for dropped and HTTP traffic we also want to have metrics specified by pod.
 
@@ -81,7 +80,7 @@ It is not yet possible to get metrics from Cilium Envoy (port 9095). Envoy only 
 {{% /alert %}}
 
 
-## Task {{% param sectionnumber %}}.2:  Store and visualize metrics
+## {{% task %}} Store and visualize metrics
 
 To make sense of metrics we store them in Prometheus and visualize them with Grafana dashboards.
 Install both into `cilium-monitoring` Namespace to store and visualize Cilium and Hubble metrics.

--- a/content/en/docs/04/_index.md
+++ b/content/en/docs/04/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "4. Metrics"
+title: "Metrics"
 weight: 4
 sectionnumber: 4
 OnlyWhenNot: techlab

--- a/content/en/docs/05/_index.md
+++ b/content/en/docs/05/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "5. Troubleshooting"
+title: "Troubleshooting"
 weight: 5
 sectionnumber: 5
 OnlyWhenNot: techlab
@@ -57,7 +57,6 @@ Global Identity Range:   min 256, max 65535
 Hubble:                  Ok   Current/Max Flows: 4095/4095 (100.00%), Flows/s: 10.60   Metrics: Ok
 Encryption:              Disabled
 Cluster health:          1/1 reachable   (2022-08-10T12:20:16Z)
-
 ```
 
 More detailed information about the status of Cilium can be inspected with:

--- a/content/en/docs/05/_index.md
+++ b/content/en/docs/05/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Troubleshooting"
 weight: 5
-sectionnumber: 5
 OnlyWhenNot: techlab
 ---
 

--- a/content/en/docs/06/_index.md
+++ b/content/en/docs/06/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Network Policies"
 weight: 6
-sectionnumber: 6
 OnlyWhenNot: techlab
 ---
 
@@ -14,7 +13,7 @@ If you are not yet familiar with Kubernetes Network Policies we suggest going to
 {{% /alert %}}
 
 
-## Task {{% param sectionnumber %}}.1: Cilium Endpoints and Identities
+## {{% task %}} Cilium Endpoints and Identities
 
 Each Pod from our simple application is represented in Cilium as an [Endpoint](https://docs.cilium.io/en/stable/concepts/terminology/#endpoint). We can use the `cilium` tool inside a Cilium Pod to list them.
 
@@ -57,7 +56,7 @@ kubectl delete pod test-identity
 We see that the number for this Pod in the column IDENTITY has changed after we added another label. If you run `endpoint list` right after pod-labeling you might also see `waiting-for-identity` as the status of the endpoint.
 
 
-## Task {{% param sectionnumber %}}.2: Verify connectivity
+## {{% task %}} Verify connectivity
 
 Make sure your `FRONTEND` and `NOT_FRONTEND` environment variable are still set. Otherwise set them again:
 
@@ -118,7 +117,7 @@ and we see, both applications can connect to the `backend` application.
 Until now ingress and egress policy enforcement are still disabled on all of our pods because no network policy has been imported yet selecting any of the pods. Let us change this.
 
 
-## Task {{% param sectionnumber %}}.3: Deny traffic with a Network Policy
+## {{% task %}} Deny traffic with a Network Policy
 
 We block traffic by applying a network policy. Create a file `backend-ingress-deny.yaml` with the following content:
 
@@ -148,7 +147,7 @@ backend-ingress-deny   app=backend    2s
 ```
 
 
-## Task {{% param sectionnumber %}}.4: Verify connectivity again
+## {{% task %}} Verify connectivity again
 
 We can now execute the connectivity check again:
 
@@ -190,7 +189,7 @@ In Grafana browse to the dashboard `Hubble`. You should see now data in more gra
 Let's now selectively re-allow traffic again, but only from frontend to backend.
 
 
-## Task {{% param sectionnumber %}}.5: Allow traffic from frontend to backend
+## {{% task %}} Allow traffic from frontend to backend
 
 We can do it by crafting a new network policy manually, but we can also use the Network Policy Editor to help us out:
 
@@ -313,7 +312,7 @@ Jan 13 12:54:49.922: default/not-frontend-8f467ccbd-lh4w4:37134 <> default/backe
 ```
 
 
-## Task {{% param sectionnumber %}}.6: Inspecting the Cilium endpoints again
+## {{% task %}} Inspecting the Cilium endpoints again
 
 We can now check the Cilium endpoints again.
 

--- a/content/en/docs/06/_index.md
+++ b/content/en/docs/06/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "6. Network Policies"
+title: "Network Policies"
 weight: 6
 sectionnumber: 6
 OnlyWhenNot: techlab
@@ -141,7 +141,7 @@ kubectl get netpol
 which gives you an output similar to this:
 
 ```
-                                                    
+
 NAME                   POD-SELECTOR   AGE
 backend-ingress-deny   app=backend    2s
 
@@ -325,11 +325,11 @@ And now we see that the pods with the label `app=backend` now have ingress polic
 
 
 ```
-ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                        IPv6   IPv4         STATUS   
-           ENFORCEMENT        ENFORCEMENT                                                                                                                         
-42         Enabled            Disabled          82094      k8s:app=backend                                                                           10.1.0.208   ready   
-                                                           k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default                                         
-                                                           k8s:io.cilium.k8s.policy.cluster=cluster1                                                                      
-                                                           k8s:io.cilium.k8s.policy.serviceaccount=default                                                                
-                                                           k8s:io.kubernetes.pod.namespace=default                                                                        
+ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                        IPv6   IPv4         STATUS
+           ENFORCEMENT        ENFORCEMENT
+42         Enabled            Disabled          82094      k8s:app=backend                                                                           10.1.0.208   ready
+                                                           k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default
+                                                           k8s:io.cilium.k8s.policy.cluster=cluster1
+                                                           k8s:io.cilium.k8s.policy.serviceaccount=default
+                                                           k8s:io.kubernetes.pod.namespace=default
 ```

--- a/content/en/docs/07/01/_index.md
+++ b/content/en/docs/07/01/_index.md
@@ -1,11 +1,10 @@
 ---
-title: "7.1 DNS-aware Network Policy"
+title: "DNS-aware Network Policy"
 weight: 71
-sectionnumber: 7.1
 ---
 
 
-## Task {{% param sectionnumber %}}.1: Create and use a DNS-aware Network Policy
+## {{% task %}} Create and use a DNS-aware Network Policy
 
 In this task, we want to keep our backend pods from reaching anything except FQDN kubernetes.io.
 
@@ -27,10 +26,10 @@ kubectl exec -ti ${BACKEND} -- curl -Ik --connect-timeout 5 https://cilium.io | 
 ```
 
 ```
-# Call to https://kubernetes.io 
-HTTP/2 200 
+# Call to https://kubernetes.io
+HTTP/2 200
 # Call to https://cilium.io
-HTTP/2 200 
+HTTP/2 200
 ```
 
 Again, in Kubernetes, all traffic is allowed by default, and since we did not apply any Egress network policy for now, connections from the backend pods are not blocked.
@@ -52,7 +51,7 @@ kubectl apply -f backend-egress-allow-fqdn.yaml
 and check if the `CiliumNetworkPolicy` was created:
 
 ```bash
-kubectl get cnp                                
+kubectl get cnp
 ```
 
 ```
@@ -73,8 +72,8 @@ kubectl exec -ti ${BACKEND} -- curl -Ik --connect-timeout 5 https://cilium.io | 
 ```
 
 ```
-# Call to https://kubernetes.io 
-HTTP/2 200 
+# Call to https://kubernetes.io
+HTTP/2 200
 # Call to https://cilium.io
 curl: (28) Connection timed out after 5001 milliseconds
 command terminated with exit code 28
@@ -87,7 +86,7 @@ You can now check the `Hubble Metrics` dashboard in Grafana again. The graphs un
 With the ingress and egress policies in place on `app=backend` pods, we have implemented a simple zero-trust model to all traffic to and from our backend. In a real-world scenario, cluster administrators may leverage network policies and overlay them at all levels and for all kinds of traffic.
 
 
-## Task {{% param sectionnumber %}}.2: Cleanup
+## {{% task %}} Cleanup
 
 To not mess up the proceeding labs we are going to delete the `CiliumNetworkPolicy` again and therefore allow all egress traffic again:
 

--- a/content/en/docs/07/02/_index.md
+++ b/content/en/docs/07/02/_index.md
@@ -1,11 +1,10 @@
 ---
-title: "7.2 HTTP-aware L7 Policy"
+title: "HTTP-aware L7 Policy"
 weight: 72
-sectionnumber: 7.2
 ---
 
 
-## Task {{% param sectionnumber %}}.1: Deploy a new Demo Application
+## {{% task %}} Deploy a new Demo Application
 
 In this Star Wars inspired example, there are three microservices applications: deathstar, tiefighter, and xwing. The deathstar runs an HTTP webservice on port 80, which is exposed as a Kubernetes Service to load balance requests to deathstar across two Pod replicas. The deathstar service provides landing services to the empire’s spaceships so that they can request a landing port. The tiefighter Pod represents a landing-request client service on a typical empire ship and xwing represents a similar service on an alliance ship. They exist so that we can test different security policies for access control to deathstar landing services.
 
@@ -52,7 +51,7 @@ command terminated with exit code 28
 ```
 
 
-## Task {{% param sectionnumber %}}.2: Apply and Test HTTP-aware L7 Policy
+## {{% task %}} Apply and Test HTTP-aware L7 Policy
 
 In the simple scenario above, it was sufficient to either give tiefighter / xwing full access to deathstar’s API or no access at all. But to provide the strongest security (i.e., enforce least-privilege isolation) between microservices, each service that calls deathstar’s API should be limited to making only the set of HTTP requests it requires for legitimate operation.
 

--- a/content/en/docs/07/_index.md
+++ b/content/en/docs/07/_index.md
@@ -1,7 +1,6 @@
 ---
-title: "7. Cilium Network Policies"
+title: "Cilium Network Policies"
 weight: 7
-sectionnumber: 7
 ---
 
 ## Cilium Network Policies

--- a/content/en/docs/08/_index.md
+++ b/content/en/docs/08/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "8. Transparent Encryption"
+title: "Transparent Encryption"
 weight: 8
 sectionnumber: 8
 OnlyWhenNot: techlab

--- a/content/en/docs/08/_index.md
+++ b/content/en/docs/08/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Transparent Encryption"
 weight: 8
-sectionnumber: 8
 OnlyWhenNot: techlab
 ---
 ## Host traffic/endpoint traffic encryption
@@ -9,7 +8,7 @@ OnlyWhenNot: techlab
 To secure communication inside a Kubernetes cluster Cilium supports transparent encryption of traffic between Cilium-managed endpoints either using IPsec or [WireGuard®](https://www.wireguard.com/).
 
 
-## Task {{% param sectionnumber %}}.1: Increase cluster size
+## {{% task %}} Increase cluster size
 
 By default Minikube creates single-node clusters. Add a second node to the cluster:
 
@@ -18,7 +17,7 @@ minikube -p cluster1 node add
 ```
 
 
-## Task {{% param sectionnumber %}}.2: Move frontend app to a different node
+## {{% task %}} Move frontend app to a different node
 
 To see traffic between nodes, we move the frontend pod from Chapter 3 to the newly created node:
 
@@ -50,7 +49,7 @@ xwing                          1/1     Running       0             11m   10.1.0.
 ```
 
 
-## Task {{% param sectionnumber %}}.3:  Sniff traffic between nodes
+## {{% task %}} Sniff traffic between nodes
 
 To check if we see unencrypted traffic between nodes we will use tcpdump.
 Let us filter on the host interfce for all packets containing the string `password`:
@@ -72,7 +71,7 @@ done
 You should now see our string `password` sniffed in the network traffic. Hit `Ctrl+C` to stop sniffing but keep the second terminal open.
 
 
-## Task {{% param sectionnumber %}}.4:  Enable node traffic encryption with WireGuard
+## {{% task %}} Enable node traffic encryption with WireGuard
 
 Enabling WireGuard based encryption with Helm is simple:
 
@@ -110,7 +109,7 @@ kubectl -n kube-system rollout restart ds cilium
 Currently, L7 policy enforcement and visibility is [not supported](https://github.com/cilium/cilium/issues/15462) with WireGuard, this is why we have to disable it.
 
 
-## Task {{% param sectionnumber %}}.5:  Verify encryption is working
+## {{% task %}} Verify encryption is working
 
 
 Verify the number of peers in encryption is 1 (this can take a while, the number is sum of nodes - 1)
@@ -144,7 +143,7 @@ As you should see the traffic is encrypted now and we can't find our string anym
 Hit `Ctrl+C` to stop sniffing. You can close the second terminal with `exit`.
 
 
-## Task {{% param sectionnumber %}}.6: CleanUp
+## {{% task %}} CleanUp
 
 To not mess up the next ClusterMesh Lab we are going to disable WireGuard encryption again:
 

--- a/content/en/docs/09/01/_index.md
+++ b/content/en/docs/09/01/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "9.1 Enable Cluster Mesh"
+title: "Enable Cluster Mesh"
 weight: 91
 sectionnumber: 91
 OnlyWhenNot: techlab

--- a/content/en/docs/09/01/_index.md
+++ b/content/en/docs/09/01/_index.md
@@ -1,12 +1,11 @@
 ---
 title: "Enable Cluster Mesh"
 weight: 91
-sectionnumber: 91
 OnlyWhenNot: techlab
 ---
 
 
-## Task {{% param sectionnumber %}}.1: Create a second Kubernetes Cluster
+## {{% task %}} Create a second Kubernetes Cluster
 
 To create a Cluster Mesh, we need a second Kubernetes cluster. For the Cluster Mesh to work, the PodCIDR ranges in all clusters and nodes must be non-conflicting and have unique IP addresses. The nodes in all clusters must have IP connectivity between each other and the network between the clusters must allow inter-cluster communication.
 
@@ -86,7 +85,7 @@ kube-system   storage-provisioner                1/1     Running   1          49
 The second cluster and Cilium is ready to use.
 
 
-## Task {{% param sectionnumber %}}.2: Enable Cluster Mesh on both Cluster
+## {{% task %}} Enable Cluster Mesh on both Cluster
 
 Now let us enable the Cluster Mesh using the `cilium` CLI on both clusters:
 
@@ -166,7 +165,7 @@ to wait for the connection to be successful. The output should be:
 The two clusters are now connected.
 
 
-## Task {{% param sectionnumber %}}.3: Cluster Mesh Troubleshooting
+## {{% task %}} Cluster Mesh Troubleshooting
 
 Use the following list of steps to troubleshoot issues with Cluster Mesh:
 

--- a/content/en/docs/09/02/_index.md
+++ b/content/en/docs/09/02/_index.md
@@ -1,14 +1,13 @@
 ---
 title: "Load-balancing with Global Services"
 weight: 92
-sectionnumber: 9.2
 OnlyWhenNot: techlab
 ---
 
 This lab will guide you to perform load-balancing and service discovery across multiple Kubernetes clusters.
 
 
-## Task {{% param sectionnumber %}}.1: Load-balancing with Global Services
+## {{% task %}} Load-balancing with Global Services
 
 Establishing load-balancing between clusters is achieved by defining a Kubernetes service with an identical name and Namespace in each cluster and adding the `annotation io.cilium/global-service: "true"` to declare it global. Cilium will automatically perform load-balancing to pods in both clusters.
 

--- a/content/en/docs/09/02/_index.md
+++ b/content/en/docs/09/02/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "9.2 Load-balancing with Global Services"
+title: "Load-balancing with Global Services"
 weight: 92
 sectionnumber: 9.2
 OnlyWhenNot: techlab
@@ -47,7 +47,7 @@ Now you can execute from either cluster the following command (there are two x-w
 
 ```bash
 XWINGPOD=$(kubectl --context cluster1 get pod -l name=x-wing -o jsonpath="{.items[0].metadata.name}")
-for i in {1..10}; do                                       
+for i in {1..10}; do
   kubectl --context cluster1  exec -it $XWINGPOD -- curl -m 1 rebel-base
 done
 ```

--- a/content/en/docs/09/03/_index.md
+++ b/content/en/docs/09/03/_index.md
@@ -1,10 +1,9 @@
 ---
 title: "Network Policies"
 weight: 93
-sectionnumber: 9.3
 ---
 
-## Task {{% param sectionnumber %}}.1: Allowing Specific Communication Between Clusters
+## {{% task %}} Allowing Specific Communication Between Clusters
 
 
 The following policy illustrates how to allow particular pods to communicate between two clusters.
@@ -56,7 +55,7 @@ command terminated with exit code 28
 All connections to `cluster2` are dropped while the ones to `cluster1` are still working.
 
 
-## Task {{% param sectionnumber %}}.2: Cleanup
+## {{% task %}} Cleanup
 
 We will disconnect our cluster mesh again and delete the second cluster:
 

--- a/content/en/docs/09/03/_index.md
+++ b/content/en/docs/09/03/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "9.3 Network Policies"
+title: "Network Policies"
 weight: 93
 sectionnumber: 9.3
 ---
@@ -28,7 +28,7 @@ Let us run our `curl` `for` loop again
 
 ```bash
 XWINGPOD=$(kubectl --context cluster1 get pod -l name=x-wing -o jsonpath="{.items[0].metadata.name}")
-for i in {1..10}; do                                       
+for i in {1..10}; do
   kubectl --context cluster1 exec -it $XWINGPOD -- curl -m 1 rebel-base
 done
 ```

--- a/content/en/docs/09/_index.md
+++ b/content/en/docs/09/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "9. Cluster Mesh"
+title: "Cluster Mesh"
 weight: 9
 sectionnumber: 9
 OnlyWhenNot: techlab

--- a/content/en/docs/09/_index.md
+++ b/content/en/docs/09/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Cluster Mesh"
 weight: 9
-sectionnumber: 9
 OnlyWhenNot: techlab
 ---

--- a/content/en/docs/10/01/_index.md
+++ b/content/en/docs/10/01/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "10.1 Host Firewall"
+title: "Host Firewall"
 weight: 101
 sectionnumber: 10.1
 OnlyWhenNot: techlab
@@ -106,23 +106,23 @@ You will see that the ingress policy enforcement for the `reserved:host` endpoin
 
 ```
 Defaulted container "cilium-agent" out of: cilium-agent, mount-cgroup (init), clean-cilium-state (init)
-ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                  IPv6   IPv4         STATUS   
-           ENFORCEMENT        ENFORCEMENT                                                                                                                   
-671        Disabled (Audit)   Disabled          1          k8s:minikube.k8s.io/commit=3e64b11ed75e56e4898ea85f96b2e4af0301f43d                              ready   
-                                                           k8s:minikube.k8s.io/name=cluster1                                                                        
-                                                           k8s:minikube.k8s.io/updated_at=2022_02_14T13_45_35_0700                                                  
-                                                           k8s:minikube.k8s.io/version=v1.25.1                                                                      
-                                                           k8s:node-access=ssh                                                                                      
-                                                           k8s:node-role.kubernetes.io/control-plane                                                                
-                                                           k8s:node-role.kubernetes.io/master                                                                       
-                                                           k8s:node.kubernetes.io/exclude-from-external-load-balancers                                              
-                                                           reserved:host                                                                                            
-810        Disabled           Disabled          129160     k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system          10.1.0.249   ready   
-                                                           k8s:io.cilium.k8s.policy.cluster=cluster1                                                                
-                                                           k8s:io.cilium.k8s.policy.serviceaccount=coredns                                                          
-                                                           k8s:io.kubernetes.pod.namespace=kube-system                                                              
-                                                           k8s:k8s-app=kube-dns                                                                                     
-4081       Disabled           Disabled          4          reserved:health                  
+ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                  IPv6   IPv4         STATUS
+           ENFORCEMENT        ENFORCEMENT
+671        Disabled (Audit)   Disabled          1          k8s:minikube.k8s.io/commit=3e64b11ed75e56e4898ea85f96b2e4af0301f43d                              ready
+                                                           k8s:minikube.k8s.io/name=cluster1
+                                                           k8s:minikube.k8s.io/updated_at=2022_02_14T13_45_35_0700
+                                                           k8s:minikube.k8s.io/version=v1.25.1
+                                                           k8s:node-access=ssh
+                                                           k8s:node-role.kubernetes.io/control-plane
+                                                           k8s:node-role.kubernetes.io/master
+                                                           k8s:node.kubernetes.io/exclude-from-external-load-balancers
+                                                           reserved:host
+810        Disabled           Disabled          129160     k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system          10.1.0.249   ready
+                                                           k8s:io.cilium.k8s.policy.cluster=cluster1
+                                                           k8s:io.cilium.k8s.policy.serviceaccount=coredns
+                                                           k8s:io.kubernetes.pod.namespace=kube-system
+                                                           k8s:k8s-app=kube-dns
+4081       Disabled           Disabled          4          reserved:health
 ```
 
 

--- a/content/en/docs/10/01/_index.md
+++ b/content/en/docs/10/01/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Host Firewall"
 weight: 101
-sectionnumber: 10.1
 OnlyWhenNot: techlab
 ---
 
@@ -9,7 +8,7 @@ OnlyWhenNot: techlab
 Cilium is capable to act as a host firewall to enforce security policies for Kubernetes nodes. In this lab, we are going to show you briefly how this works.
 
 
-## Task {{% param sectionnumber %}}.1: Enable the Host Firewall in Cilium
+## {{% task %}} Enable the Host Firewall in Cilium
 
 We need to enable the host firewall in the Cilium config. This can be done using Helm:
 
@@ -47,7 +46,7 @@ kubectl -n kube-system rollout restart ds/cilium
 At this point, the Cilium-managed nodes are ready to enforce Network Policies.
 
 
-## Task {{% param sectionnumber %}}.2: Attach a Label to the Node
+## {{% task %}} Attach a Label to the Node
 
 In this lab, we will apply host policies only to nodes with the label `node-access=ssh`. We thus first need to attach that label to a node in the cluster.
 
@@ -56,7 +55,7 @@ kubectl label node cluster1 node-access=ssh
 ```
 
 
-## Task {{% param sectionnumber %}}.2: Enable Policy Audit Mode for the Host Endpoint
+## {{% task %}} Enable Policy Audit Mode for the Host Endpoint
 
 [Host Policies](https://docs.cilium.io/en/latest/policy/language/#hostpolicies) enforce access control over connectivity to and from nodes. Particular care must be taken to ensure that when host policies are imported, Cilium does not block access to the nodes or break the cluster’s normal behavior (for example by blocking communication with kube-apiserver).
 
@@ -81,7 +80,7 @@ PolicyAuditMode          Enabled
 ```
 
 
-## Task {{% param sectionnumber %}}.3: Apply a Host Network Policy
+## {{% task %}} Apply a Host Network Policy
 
 Host Policies match on node labels using a Node Selector to identify the nodes to which the policy applies. The following policy applies to all nodes. It allows communications from outside the cluster only on port TCP/22. All communications from the cluster to the hosts are allowed.
 
@@ -165,7 +164,7 @@ Policy verdict log: flow 0x6b5b1b60 local EP ID 671, remote ID world, proto 6, i
 ```
 
 
-## Task {{% param sectionnumber %}}.4: Clean Up
+## {{% task %}} Clean Up
 
 Once you are confident all required communication to the host from outside the cluster is allowed, you can disable policy audit mode to enforce the host policy.
 

--- a/content/en/docs/10/02/_index.md
+++ b/content/en/docs/10/02/_index.md
@@ -1,14 +1,13 @@
 ---
 title: "Kubernetes Without kube-proxy"
 weight: 102
-sectionnumber: 10.2
 OnlyWhenNot: techlab
 ---
 
 In this lab, we are going to provision a new Kubernetes cluster without `kube-proxy` to use Cilium as a full replacement for it.
 
 
-## Task {{% param sectionnumber %}}.1: Deploy a new Kubernetes Cluster without `kube-proxy`
+## {{% task %}} Deploy a new Kubernetes Cluster without `kube-proxy`
 
 
 Create a new Kubernetes cluster using `minikube`. As `minikube` uses `kubeadm` we can skip the phase where `kubeadm` installs the `kube-proxy` addon. Execute the following command to create a third cluster:
@@ -36,7 +35,7 @@ minikube start --network-plugin=cni --cni=false --kubernetes-version={{% param "
 ```
 
 
-## Task {{% param sectionnumber %}}.1: Deploy Cilium and enable the Kube Proxy replacement
+## {{% task %}} Deploy Cilium and enable the Kube Proxy replacement
 
 As the `cilium` and `cilium-operator` Pods by default try to communicate with the Kubernetes API using the default `kubernetes` service IP, they cannot do this with disabled `kube-proxy`. We, therefore, need to set the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables to tell the two Pods how to connect to the Kubernetes API.
 
@@ -110,7 +109,7 @@ storage-provisioner                1/1     Running   13 (17m ago)   59m
 ```
 
 
-## Task {{% param sectionnumber %}}.2: Deploy our simple app again to the new cluster
+## {{% task %}} Deploy our simple app again to the new cluster
 
 As this is a new cluster we want to deploy our `simple-app.yaml` from lab 03 again to run some experiments. Run the following command using the `simple-app.yaml` from lab 03:
 

--- a/content/en/docs/10/02/_index.md
+++ b/content/en/docs/10/02/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "10.2 Kubernetes Without kube-proxy"
+title: "Kubernetes Without kube-proxy"
 weight: 102
 sectionnumber: 10.2
 OnlyWhenNot: techlab

--- a/content/en/docs/10/_index.md
+++ b/content/en/docs/10/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "10. Advanced Networking"
+title: "Advanced Networking"
 weight: 10
 sectionnumber: 10
 OnlyWhenNot: techlab

--- a/content/en/docs/10/_index.md
+++ b/content/en/docs/10/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Advanced Networking"
 weight: 10
-sectionnumber: 10
 OnlyWhenNot: techlab
 ---

--- a/content/en/docs/11/_index.md
+++ b/content/en/docs/11/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "11. Cilium Service Mesh"
+title: "Cilium Service Mesh"
 weight: 11
 sectionnumber: 11
 OnlyWhenNot: techlab
@@ -128,6 +128,7 @@ We see both backends replying. If you call it many times the distribution would 
 
 ```bash
 [                                                                                                                               [10/1834]
+<<<<<<< HEAD
   {                                                                                                                                      
     "id": 1,                                                                                                                             
     "body": "another secret information from a different backend"                                                                                                 
@@ -138,6 +139,18 @@ We see both backends replying. If you call it many times the distribution would 
     "id": 1,                                                                                                                             
     "body": "secret information"                                                                                                         
   }                                                                                                                                      
+=======
+  {
+    "id": 1,
+    "body": "another secret information"
+  }
+]pod "curl" deleted
+[
+  {
+    "id": 1,
+    "body": "secret information"
+  }
+>>>>>>> 82da453 (Use automatic section numbering)
 ]pod "curl" deleted
 ```
 This basic traffic control example shows only one function of Cilium Service Mesh, other features include i.e. TLS termination, support for tracing and canary-rollouts.

--- a/content/en/docs/11/_index.md
+++ b/content/en/docs/11/_index.md
@@ -1,13 +1,12 @@
 ---
 title: "Cilium Service Mesh"
 weight: 11
-sectionnumber: 11
 OnlyWhenNot: techlab
 ---
 With release 1.12 Cilium enabled direct ingress support and service mesh features like layer 7 loadbalancing
 
 
-## Task {{% param sectionnumber %}}.1: Installation
+## {{% task %}} Installation
 
 
 ```bash
@@ -28,7 +27,7 @@ kubectl -n kube-system rollout restart ds/cilium
 ```
 
 
-## Task {{% param sectionnumber %}}.2: Create Ingress
+## {{% task %}} Create Ingress
 
 Cilium Service Mesh can handle ingress traffic with its Envoy proxy.
 
@@ -69,7 +68,7 @@ You should get the following output:
 ```
 
 
-## Task {{% param sectionnumber %}}.3: Layer 7 Loadbalancing
+## {{% task %}} Layer 7 Loadbalancing
 
 Ingress alone is not really a Service Mesh feature. Let us test a traffic control example by loadbalancing a service inside the proxy.
 
@@ -127,8 +126,7 @@ done
 We see both backends replying. If you call it many times the distribution would be equal.
 
 ```bash
-[                                                                                                                               [10/1834]
-<<<<<<< HEAD
+[
   {                                                                                                                                      
     "id": 1,                                                                                                                             
     "body": "another secret information from a different backend"                                                                                                 
@@ -139,18 +137,6 @@ We see both backends replying. If you call it many times the distribution would 
     "id": 1,                                                                                                                             
     "body": "secret information"                                                                                                         
   }                                                                                                                                      
-=======
-  {
-    "id": 1,
-    "body": "another secret information"
-  }
-]pod "curl" deleted
-[
-  {
-    "id": 1,
-    "body": "secret information"
-  }
->>>>>>> 82da453 (Use automatic section numbering)
 ]pod "curl" deleted
 ```
 This basic traffic control example shows only one function of Cilium Service Mesh, other features include i.e. TLS termination, support for tracing and canary-rollouts.


### PR DESCRIPTION
I updated the pages in `07` to use the `task` shortcode instead of `param sectionnumber`. This should also be done for the rest of the pages.

Requires: https://github.com/acend/docsy-plus/pull/14